### PR TITLE
Match wildcard domains recursively like HTTP proxies

### DIFF
--- a/app/airlock-cli/src/network/check_target_conflicts.rs
+++ b/app/airlock-cli/src/network/check_target_conflicts.rs
@@ -14,6 +14,7 @@
 //!    ([`check_reverse_forward_conflicts`]). Two `.guest` entries
 //!    can't both bind the same `127.0.0.1:<port>`.
 
+use super::matchers;
 use super::target::NetworkTarget;
 
 /// A labeled reverse port forward, used for error messages when two
@@ -87,19 +88,20 @@ pub fn check_passthrough_conflicts(
 }
 
 /// True iff there exists at least one concrete `(host, port)` that both
-/// targets would match, using the same pattern semantics as
+/// targets would match, using the same wildcard semantics as
 /// [`super::matchers::host_matches`]:
 ///
 /// - `*` matches any host.
-/// - `*.<suffix>` matches exactly one leading label (no apex, no
-///   multi-label prefix).
+/// - `*.<suffix>` matches any subdomain of `<suffix>` at any depth —
+///   `*.example.com` matches both `api.example.com` and `a.b.example.com`.
 /// - anything else is an exact literal (with localhost aliases).
 ///
-/// Under these rules, two `*.suffix` wildcards overlap iff their
-/// suffixes are identical — a multi-label difference can never be
-/// bridged by a single-label wildcard. Wildcard × literal reduces to
-/// "does the literal match the wildcard." `*` vs anything always
-/// overlaps.
+/// Two `*.suffix` wildcards overlap when their suffixes are equal, or when
+/// one suffix is a dot-separated sub-suffix of the other (e.g.
+/// `*.example.com` and `*.prod.example.com` overlap because any host
+/// matching the narrower pattern also matches the broader one). Wildcard ×
+/// literal reduces to "does the literal match the wildcard." `*` vs
+/// anything always overlaps.
 fn targets_overlap(a: &NetworkTarget, b: &NetworkTarget) -> bool {
     ports_overlap(a.port, b.port) && hosts_overlap(&a.host, &b.host)
 }
@@ -116,22 +118,19 @@ fn hosts_overlap(a: &str, b: &str) -> bool {
         return true;
     }
     match (a.strip_prefix("*."), b.strip_prefix("*.")) {
-        (Some(sa), Some(sb)) => sa == sb,
-        (Some(suffix), None) => wildcard_matches_literal(suffix, b),
-        (None, Some(suffix)) => wildcard_matches_literal(suffix, a),
+        // Both wildcards: *.A and *.B overlap iff A==B, or one suffix contains
+        // the other as a dot-separated sub-suffix (e.g. "example.com" and
+        // "prod.example.com"), because a multi-label host like `x.prod.example.com`
+        // would match both `*.example.com` and `*.prod.example.com` at runtime.
+        (Some(sa), Some(sb)) => {
+            sa == sb
+                || sa.strip_suffix(sb).is_some_and(|p| p.ends_with('.'))
+                || sb.strip_suffix(sa).is_some_and(|p| p.ends_with('.'))
+        }
+        // Wildcard × literal: delegate to host_matches so semantics stay in sync.
+        (Some(_sa), None) => matchers::host_matches(b, a),
+        (None, Some(_sb)) => matchers::host_matches(a, b),
         (None, None) => a == b || (is_localhost(a) && is_localhost(b)),
-    }
-}
-
-/// `*.<suffix>` matches `host` iff `host = <label>.<suffix>` where
-/// `<label>` is non-empty and contains no dots.
-fn wildcard_matches_literal(suffix: &str, host: &str) -> bool {
-    match host.strip_suffix(suffix) {
-        Some(prefix) => match prefix.strip_suffix('.') {
-            Some(label) => !label.is_empty() && !label.contains('.'),
-            None => false,
-        },
-        None => false,
     }
 }
 
@@ -187,12 +186,12 @@ mod tests {
     }
 
     #[test]
-    fn wildcard_subdomain_covers_single_label_subdomain_only() {
+    fn wildcard_subdomain_covers_subdomains_at_any_depth() {
         assert!(targets_overlap(&t("*.example.com"), &t("api.example.com")));
-        // Apex is NOT matched by `*.example.com` (RFC 6125).
+        // Multi-label hosts are matched: `*.example.com` matches `a.b.example.com`.
+        assert!(targets_overlap(&t("*.example.com"), &t("a.b.example.com")));
+        // Apex is NOT matched by `*.example.com`.
         assert!(!targets_overlap(&t("*.example.com"), &t("example.com")));
-        // Multi-label host is NOT matched by a single-label wildcard.
-        assert!(!targets_overlap(&t("*.example.com"), &t("a.b.example.com")));
     }
 
     #[test]
@@ -202,13 +201,13 @@ mod tests {
     }
 
     #[test]
-    fn wildcard_wildcard_overlaps_only_when_suffixes_equal() {
-        // Different suffixes can never overlap: a single-label wildcard
-        // can't bridge a multi-label difference.
-        assert!(!targets_overlap(
+    fn wildcard_wildcard_overlap() {
+        // Nested suffix overlaps: `a.prod.example.com` matches both.
+        assert!(targets_overlap(
             &t("*.example.com"),
             &t("*.prod.example.com")
         ));
+        // Unrelated suffixes never overlap.
         assert!(!targets_overlap(&t("*.example.com"), &t("*.foo.com")));
         // Same suffix overlaps.
         assert!(targets_overlap(&t("*.example.com"), &t("*.example.com")));
@@ -275,12 +274,12 @@ mod tests {
     }
 
     #[test]
-    fn nested_wildcards_with_different_suffixes_do_not_conflict() {
-        // `*.example.com` only matches one-label subdomains, so it
-        // cannot overlap a deeper wildcard like `*.prod.example.com`.
+    fn nested_wildcards_with_suffix_relationship_conflict() {
+        // `a.prod.example.com` matches both `*.example.com` (multi-label)
+        // and `*.prod.example.com`, so these patterns overlap.
         let pt = vec![labeled("pt", "*.example.com")];
         let mw = vec![labeled("mitm", "*.prod.example.com")];
-        assert!(check_passthrough_conflicts(&pt, &mw).is_ok());
+        assert!(check_passthrough_conflicts(&pt, &mw).is_err());
     }
 
     #[test]

--- a/app/airlock-cli/src/network/matchers.rs
+++ b/app/airlock-cli/src/network/matchers.rs
@@ -2,25 +2,28 @@
 ///
 /// Supported pattern forms:
 /// - `*` — matches any host.
-/// - `*.<suffix>` — matches exactly one leading label: `<label>.<suffix>`
-///   where `<label>` is non-empty and contains no dots. So
-///   `*.example.com` matches `api.example.com` but NOT the apex
-///   `example.com` and NOT `a.b.example.com`. This follows RFC 6125
-///   TLS wildcard rules.
+/// - `*.<suffix>` — matches any subdomain of `<suffix>`, including
+///   nested subdomains. So `*.example.com` matches `api.example.com`
+///   and `a.b.example.com`, but NOT the apex `example.com`.
 /// - anything else — exact string match, with localhost aliases
 ///   (`localhost`, `127.0.0.1`, `::1`) treated as equivalent.
 ///
 /// Patterns beginning with `*` but not `*.` (e.g. `*foo.com`) are not
 /// wildcards in this scheme and will never match any real hostname.
+///
+/// This intentionally deviates from RFC 6125 (TLS certificate wildcard
+/// rules), which restricts `*` to a single DNS label. We follow the
+/// convention used by modern HTTP proxies and CDNs (Nginx, Envoy,
+/// Cloudflare) where `*.example.com` matches all subdomain depths.
+/// If strict single-label matching is needed in the future, this
+/// function must be redesigned.
 pub fn host_matches(host: &str, pattern: &str) -> bool {
     if pattern == "*" {
         true
     } else if let Some(suffix) = pattern.strip_prefix("*.") {
         match host.strip_suffix(suffix) {
-            Some(prefix) => match prefix.strip_suffix('.') {
-                Some(label) => !label.is_empty() && !label.contains('.'),
-                None => false,
-            },
+            // prefix must be at least "x." — a non-empty label followed by a dot.
+            Some(prefix) => prefix.len() > 1 && prefix.ends_with('.'),
             None => false,
         }
     } else if is_localhost(pattern) {
@@ -46,20 +49,20 @@ mod tests {
     }
 
     #[test]
-    fn wildcard_matches_exactly_one_leading_label() {
+    fn wildcard_matches_single_subdomain() {
         assert!(host_matches("api.example.com", "*.example.com"));
         assert!(host_matches("www.example.com", "*.example.com"));
     }
 
     #[test]
-    fn wildcard_does_not_match_apex() {
-        assert!(!host_matches("example.com", "*.example.com"));
+    fn wildcard_matches_nested_subdomains() {
+        assert!(host_matches("a.b.example.com", "*.example.com"));
+        assert!(host_matches("x.y.z.example.com", "*.example.com"));
     }
 
     #[test]
-    fn wildcard_does_not_match_multiple_labels() {
-        assert!(!host_matches("a.b.example.com", "*.example.com"));
-        assert!(!host_matches("x.y.z.example.com", "*.example.com"));
+    fn wildcard_does_not_match_without_subdomain() {
+        assert!(!host_matches("example.com", "*.example.com"));
     }
 
     #[test]

--- a/docs/log/2026-05-12-recursive-wildcard-domain-matching.md
+++ b/docs/log/2026-05-12-recursive-wildcard-domain-matching.md
@@ -1,0 +1,61 @@
+# Recursive wildcard domain matching for network filtering
+
+## Background
+
+Airlock intercepts all outbound TCP from the guest and evaluates each
+connection against configured allow/deny rules and middleware targets. Both
+use `*.suffix` wildcard patterns — e.g. `*.github.com` to allow all GitHub
+subdomains.
+
+## Problem
+
+The matcher enforced strict RFC 6125 (TLS certificate) wildcard rules, where
+`*.example.com` matches only a single DNS label:
+- ✅ `*.github.com` matched `api.github.com`
+- ❌ `*.github.com` rejected `api.business.github.com`
+
+Users writing rules for real-world services (GitHub, AWS, Google APIs) expect
+all subdomains at any depth to be covered by one wildcard entry. RFC 6125 is
+designed for TLS certificate validation, not network filtering.
+
+## Decision
+
+Change wildcard matching to follow HTTP proxy conventions (Nginx, Envoy,
+Cloudflare, HAProxy) where `*.example.com` matches any subdomain depth. AWS
+Network Firewall and Kubernetes Ingress use single-label strict matching, but
+those are endpoint/routing systems. Since Airlock is an HTTP proxy, proxy
+conventions are the appropriate reference.
+
+The implementation change is minimal — the old check stripped the suffix and
+then verified the remaining label contained no dots. The new check only
+requires the prefix to be non-empty and end with a dot:
+
+```rust
+// before
+Some(label) => !label.is_empty() && !label.contains('.'),
+
+// after
+Some(prefix) => prefix.len() > 1 && prefix.ends_with('.'),
+```
+
+Bare apex (`example.com` against `*.example.com`) still does not match, which
+is consistent across all systems reviewed.
+
+## Conflict checker alignment
+
+The startup passthrough/middleware conflict checker had its own copy of
+wildcard matching logic that was not updated alongside the matcher, leaving
+two gaps:
+
+**Wildcard × literal** — the checker's `wildcard_matches_literal` still
+rejected multi-label hosts via `!label.contains('.')`. A passthrough rule
+`*.example.com` would pass validation against middleware target
+`a.b.example.com`, even though at runtime passthrough silently wins and
+middleware never runs. Fixed by replacing the local helper with a direct call
+to `matchers::host_matches`, so the two can never diverge again.
+
+**Wildcard × wildcard** — the overlap check was `sa == sb` (equal suffixes
+only). With multi-label matching, `*.example.com` and `*.prod.example.com`
+overlap because `x.prod.example.com` matches both, but the checker accepted
+this config. Fixed by also flagging when one suffix is a dot-separated
+sub-suffix of the other: `sa == sb || sa ends with "."+sb || sb ends with "."+sa`.


### PR DESCRIPTION
I think it's right, at least my comprehension sais so. The Rust code is bit foreign to me, so I might read some bits wrong.

This makes the copilot-cli preset work better and is related on fixing copilot-cli.

Indirectly, alpine and arch repos use wildcard too, so this change effects those. And any local middleware.

The copilot commit message (there is minor detail bug I could fix...):

> Change *.example.com pattern matching from strict RFC 6125 (single DNS label only) to recursive matching that includes nested subdomains, aligned with modern HTTP proxies like Nginx, Envoy, and Cloudflare.
> 
> This fixes matching api.business.github.com against *.github.com pattern, which previously failed because RFC 6125 restricts * to exactly one label. [darn, this commit message line has wrong domain..., meta is correct though]
> 
> Research shows HTTP proxies and network filters universally use recursive matching for *.domain patterns. Airlock operates as an HTTP proxy, not a TLS certificate validator, so this convention is more appropriate.
> 
> The bare domain (example.com) still does not match *.example.com, keeping the behavior secure by default.
> 
> Tests updated: single subdomain, nested subdomains, and bare domain rejection are now explicit test cases.