### PR TITLE
Fix copilot-cli preset: correct mount, widen token injection paths

### DIFF
--- a/app/airlock-cli/src/config/presets/copilot-cli.toml
+++ b/app/airlock-cli/src/config/presets/copilot-cli.toml
@@ -1,24 +1,38 @@
 # GitHub Copilot CLI preset
+#
+# API hosts from:
+# https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/customize-the-agent-environment
 
 [env]
 COPILOT_GITHUB_TOKEN = "github_pat_NOTReal"
 
 [network.rules.copilot-cli]
 allow = [
+    "github.com:443",
     "api.github.com:443",
     "*.githubcopilot.com:443",
 ]
 
+# Middleware targets only the API hosts — not telemetry.*.githubcopilot.com —
+# so the token is not sent to telemetry endpoints.
 [network.middleware.copilot-cli-api-token]
-target = ["*.githubcopilot.com:443", "api.github.com:443"]
+target = [
+    "api.individual.githubcopilot.com:443",
+    "api.business.githubcopilot.com:443",
+    "api.enterprise.githubcopilot.com:443",
+    "api.github.com:443",
+]
 env.TOKEN = "${COPILOT_GITHUB_TOKEN}"
 script = """
-if env.TOKEN and (req:hostMatches("*.githubcopilot.com") or req.path:sub(1, 17) == "/copilot_internal") then
+local copilot = req:hostMatches("*.githubcopilot.com")
+local github = req:hostMatches("api.github.com")
+  and (req.path:sub(1, 9) == "/copilot/" or req.path:sub(1, 18) == "/copilot_internal/")
+if env.TOKEN and (copilot or github) then
   req:setHeader("Authorization", "Bearer " .. env.TOKEN)
 end
 """
 
-[mounts.copilot-gh-config]
-source = "~/.airlock/copilot"
-target = "~/.config/gh"
+[mounts.copilot-session]
+source = "~/.airlock/copilot-cli"
+target = "~/.copilot"
 missing = "create-dir"

--- a/docs/log/2026-05-12-copilot-cli-session-mount.md
+++ b/docs/log/2026-05-12-copilot-cli-session-mount.md
@@ -1,0 +1,38 @@
+# Fix Copilot CLI preset mount configuration
+
+The `copilot-cli` preset had an incorrect and unnecessary mount. It mounted
+`~/.airlock/copilot` → `~/.config/gh` — the GitHub CLI config directory —
+even though Copilot CLI doesn't use `~/.config/gh` and doesn't require `gh`
+to be installed. The actual persistent state Copilot CLI writes lives in
+`~/.copilot`.
+
+## What changed
+
+Replaced the incorrect `~/.config/gh` mount with the correct one:
+`~/.airlock/copilot-cli` → `~/.copilot` (shadow copy, `missing = "create-dir"`).
+
+This enables Copilot CLI session state to persist across sandboxes:
+- `config.json` — User settings and preferences
+- `session.db` — Session state, login data, and interaction history
+- `logs/` and `analytics/` — Activity and telemetry tracking
+
+The `~/.config/gh` mount was removed entirely. A dedicated `github-cli` preset
+can be added in the future for users who want to run `gh` inside the sandbox.
+
+The middleware `target` was narrowed from `*.githubcopilot.com` to the
+explicit API hosts (`api.githubcopilot.com`, `api.business.githubcopilot.com`)
+so the token is not sent to telemetry endpoints. The network allow list
+still uses `*.githubcopilot.com` — telemetry traffic flows but without
+the user's credential.
+
+## Documentation
+
+Rewrote the "Providing the GitHub token" section:
+- Named link to PAT creation with the correct permission label
+  ("Account > Copilot Requests")
+- Clarified the placeholder/injection model: the sandbox only ever sees a
+  placeholder value in `COPILOT_GITHUB_TOKEN`; airlock swaps in the real
+  credential at the host boundary. The previous text was contradictory —
+  it said Copilot "picks up the token" and also that "the real token never
+  enters the sandbox".
+- Added a reference link to the official Copilot CLI authentication docs.

--- a/docs/manual/src/presets/copilot-cli.md
+++ b/docs/manual/src/presets/copilot-cli.md
@@ -14,15 +14,16 @@ uses.
 - **Your token stays on the host.** Copilot requests are intercepted
   on `api.github.com` and `*.githubcopilot.com`, and the real
   `Authorization` header is injected there at host side. On
-  `api.github.com` the injection is path-scoped to
+  `api.github.com` the injection is path-scoped to `/copilot/*` and
   `/copilot_internal/*`, so any other GitHub API call an agent might
   make will not receive the Copilot token.
-- **Only Copilot endpoints are reachable** (`api.github.com` and
-  `*.githubcopilot.com`). Everything else stays blocked by your
-  deny-by-default policy.
-- **Your Copilot session survives.** `~/.config/gh` is mapped to
-  `~/.airlock/copilot/` on the host, so the `gh auth` state and
-  Copilot preferences carry over between sandboxes.
+- **Only Copilot endpoints are reachable** (`github.com`,
+  `api.github.com`, and `*.githubcopilot.com`). Everything else stays
+  blocked by your deny-by-default policy.
+- **Your Copilot session survives.** `~/.copilot` is mapped to
+  `~/.airlock/copilot-cli/` on the host, so Copilot CLI session state
+  persists across sandboxes — configuration, interaction history, and
+  the session database all carry over.
 
 ## Example `airlock.toml`
 
@@ -42,15 +43,25 @@ already installed. For a real project, you might prefer your own
 
 ## Providing the GitHub token
 
-Create a dedicated fine-grained PAT with the Copilot scopes at
-<https://github.com/settings/tokens>.
-
-Store your PAT in the airlock
+Create a [fine-grained personal access token][new-pat] with the
+**Account > Copilot Requests** permission. Store it in the airlock
 [secret vault](../secrets.md) under the name `COPILOT_GITHUB_TOKEN`:
+
+[new-pat]: https://github.com/settings/personal-access-tokens/new
 
 ```bash
 airlock secrets add COPILOT_GITHUB_TOKEN
 ```
+
+Inside the sandbox, Copilot CLI sees a placeholder value in
+`COPILOT_GITHUB_TOKEN` — no `/login` step is needed. Airlock
+intercepts outgoing API requests at the host boundary and swaps in
+the real token there. The actual credential never enters the sandbox.
+
+For more details on supported token types, see the
+[Copilot CLI authentication docs][copilot-auth].
+
+[copilot-auth]: https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli#authenticating-with-environment-variables
 
 ## Running it
 


### PR DESCRIPTION
This was my original part.

Firts, the `gh` folder was not really used, at least not for me... I might need someone else to validate this too.

The wildcard didn't originally work. It now does, as fixed in another PR. It's used here byt the `hostMatches` call (thus, this PR doesn't actually work in isolation).

I used precise api domains, based on docs, to match api endpoints only. The copilot-cli also makes requests to telemetry.*, which I didn't want to pass the token for. This could alternatively use the wildcard and then some lua script like `req.host:sub(1, 4) == "api."` or such.

Interestingly, copilot-cli internally sets `Authorization: token ...` and not the `Bearer`.

The /copilot/ path was detect from the logs.

I used the following `airlock.local.toml` to verify

```toml
[network.middleware.z-audit-token-injection]
target = [
    "*.githubcopilot.com:443",
    "api.github.com:443",
]
env.TOKEN = "${COPILOT_GITHUB_TOKEN}"
script = '''
local host = req.host
local path = req.path
local auth = req:header("Authorization")
local has_real_token = auth ~= nil and auth:find(env.TOKEN, 1, true) ~= nil
local preset_injected = auth == "Bearer " .. env.TOKEN

local token_expected
if host == "api.github.com" then
    token_expected = path:sub(1, 9) == "/copilot/" or path:sub(1, 18) == "/copilot_internal/"
else
    token_expected = host:sub(1, 4) == "api."
end

local res = req:send()

if has_real_token and not token_expected then
    local how = preset_injected and "by preset" or "in unexpected form"
    log(string.format("[SECURITY WARNING] real token leaked (%s) to %s%s (status: %d)", how, host, path, res.status))
elseif not has_real_token and token_expected then
    log(string.format("[AUDIT] %s%s - token NOT injected (status: %d)", host, path, res.status))
else
    log(string.format("[AUDIT] %s%s - preset injected: %s, status: %d",
        host, path, preset_injected and "YES" or "NO", res.status))
end
```

Copilot git commit:

> The preset mounted `~/.config/gh` for GitHub CLI state, but Copilot CLI doesn't use `gh` — its session state lives in `~/.copilot`. Replaced the mount so Copilot CLI configuration and session history persist across sandboxes.
> 
> Token injection on `api.github.com` only matched `/copilot_internal/*` but Copilot CLI also calls `/copilot/mcp_registry` and other `/copilot/` paths, causing 401s. Now both `/copilot/*` and `/copilot_internal/*` are covered. Also added `github.com:443` to the allow list for OAuth flows, and documented the required PAT permission (Account > Copilot Requests).
> 
> See docs/log/2026-05-12-copilot-cli-session-mount.md